### PR TITLE
Update convert-lang.js

### DIFF
--- a/convert-lang.js
+++ b/convert-lang.js
@@ -8,7 +8,7 @@ const spreadsheetLink = 'https://docs.google.com/spreadsheets/d/1niekzGKaM08M9oY
 
 wget({
     url: spreadsheetLink,
-    dest: inputPath + 'input.xlsx'
+    dest: inputPath + 'Original.xlsx'
 }, () => {
     const timeoutForDownload = 5000;
     // beacuase of node-wget wirtes file with createWriteStream,


### PR DESCRIPTION
The convert-lang.js used to overwrite the input.xlsx file by original file from google doc. After that it convert the overwritten input.xlsx file(which is actually the original google doc) into json files. I think the change will rename the google doc into original.xlsx, instead of overwrite my translation. I tried it and it worked :)

Oh and the arcanaLang section needs to be added in the json file.